### PR TITLE
Shuffle protein data on first load and then store in memmap (on disk) instead of in memory.

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,26 +1,33 @@
 from jina.types.document.generators import from_csv
 from jina import DocumentArray, Flow
+from jina.types.arrays.memmap import DocumentArrayMemmap
 
 from my_executors import ProtBertExecutor, MyIndexer
 from backend_config import pdb_data_path, embeddings_path, pdb_data_url
-from helpers import cull_duplicates, download_csv, log
+from helpers import cull_duplicates, download_csv, log, shuffle_csv
 
 import os
 
+proteins = DocumentArrayMemmap('./proteins-memmap')
+proteins.clear()
 
 def index():
     if not os.path.exists(pdb_data_path):
         log("Downloading data.")
         download_csv(pdb_data_url, pdb_data_path)
+
         log("Culling PDB ID duplicates.")
         cull_duplicates(pdb_data_path)
+        log("Shuffling proteins csv.")
+        shuffle_csv(pdb_data_path)
 
     log("Converting protein data to DocumentArray")
     with open(pdb_data_path) as data_file:
         docs_generator = from_csv(
             fp=data_file, field_resolver={"sequence": "text", "structureId": "id"}
         )
-        proteins = DocumentArray(docs_generator)
+        proteins.extend(DocumentArray(docs_generator))
+
     log(f"Loaded {len(proteins)} proteins from {pdb_data_path}.")
 
     log("Building index.")

--- a/backend/helpers.py
+++ b/backend/helpers.py
@@ -1,17 +1,27 @@
 from backend_config import print_logs
+import pandas as pd
+import numpy as np
+
 
 def cull_duplicates(fp):
-    import pandas as pd
-
     df = pd.read_csv(fp)
-    df = df.drop_duplicates(subset=['structureId'])
-    df[['structureId', 'sequence']].to_csv(fp, index=False)
+    df = df.drop_duplicates(subset=["structureId"])
+    df[["structureId", "sequence"]].to_csv(fp, index=False)
+
 
 def download_csv(url, fp):
     import requests
+
     response = requests.get(url)
     with open(fp, "wb") as f:
         f.write(response.content)
+
+
+def shuffle_csv(fp):
+    df = pd.read_csv(fp)
+    np.random.shuffle(df.values)
+    df.to_csv(fp, index=False)
+
 
 def log(message):
     if print_logs:


### PR DESCRIPTION

### PR type
- 🏆 **Enhancements**
- 🏠 **Internal**

### Purpose
- Shuffles proteins on first index.
- Uses memmap to store proteins instead of keeping them in memory due to large size (~50 MB+ for ~100k proteins).

### Why? 
- Currently embeddings are computed sequentially. This makes embedding a fraction of the dataset index in order of PDB ID which makes evaluating metric similarity less meaningful.
- [Memmap is preferred for large doc arrays.](https://github.com/jina-ai/jina/blob/master/.github/2.0/cookbooks/Document.md#side-by-side-vs-documentarray)
-  Helps avoid memory issues on small deployment server.

### Feedback required over
- A quick pair of :eyes: on the code

### Mentions
- @fissoreg 

### Future work
- Currently using pandas to shuffle the data. One could use the jina built in .shuffle [(see cookbook)](https://github.com/jina-ai/jina/blob/master/.github/2.0/cookbooks/Document.md). However I couldn't get this working properly.

### References
- Previous meeting with Jina AI devs.

### Legal
- [x] I have read and agreed to [the terms of contributing.](https://github.com/georgeamccarthy/protein_search/blob/license/.github/contributing.md)
